### PR TITLE
Add Streamlit dashboard app

### DIFF
--- a/streamlit_dashboard.py
+++ b/streamlit_dashboard.py
@@ -1,0 +1,167 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+from datetime import date
+
+st.set_page_config(page_title="Project M Trading Dashboard", layout="wide")
+
+plt.style.use("dark_background")  # black theme for all plots
+
+# —— CONFIG ——
+FILE_PATH = "Updated_Dataset_with_Signals_Ranked.csv"
+INITIAL_INVEST = 50_000
+CONTRIB_AMOUNT = 3_000
+CONTRIB_FREQ = 22
+MANUAL_EXIT_DATE = pd.Timestamp("2024-06-27")
+HOLD_DAYS = 25
+
+# —— LOAD DATA ——
+@st.cache_data
+def load_prices(fp):
+    df = pd.read_csv(fp)
+    df["Date"] = pd.to_datetime(df["Date"])
+    for col in ["Price", "Open"]:
+        df[col] = pd.to_numeric(
+            df[col].astype(str).str.replace(r"[$,]", "", regex=True), errors="coerce"
+        )
+    return df.sort_values("Date")
+
+df_sorted = load_prices(FILE_PATH)
+date_index = df_sorted["Date"].unique()
+
+# —— BACKTEST ——
+@st.cache_data
+def run_backtest(df):
+    cash, contrib_ctr = INITIAL_INVEST, 0
+    portfolio, trades, equity_curve = [], [], []
+
+    for i, curr_date in enumerate(date_index):
+        contrib_ctr += 1
+        if contrib_ctr == CONTRIB_FREQ:
+            cash += CONTRIB_AMOUNT
+            contrib_ctr = 0
+
+        if curr_date == MANUAL_EXIT_DATE:
+            for pos in portfolio[:]:
+                px = df.loc[(df["Company"] == pos["company"]) &
+                            (df["Date"] == curr_date), "Price"]
+                if px.empty:
+                    continue
+                px = px.iloc[0]
+                profit = (px - pos["buy_price"]) * pos["shares_bought"]
+                cash += pos["shares_bought"] * px
+                trades.append(profit > 0)
+            portfolio.clear()
+
+        todays_rows = df[df["Date"] == curr_date]
+        for _, row in todays_rows.iterrows():
+            if row["30 Day Buy Signal"] == 1 and cash > 0 and i + 1 < len(date_index):
+                nxt = df[(df["Company"] == row["Company"]) &
+                         (df["Date"] == date_index[i + 1])]
+                if nxt.empty:
+                    continue
+                next_open = nxt.iloc[0]["Open"]
+                qty = (cash * 0.30) / next_open
+                if qty >= 1:
+                    invest = qty * next_open
+                    cash -= invest
+                    buy_date = date_index[i + 1]
+                    sell_date = (date_index[i + HOLD_DAYS]
+                                 if i + HOLD_DAYS < len(date_index) else None)
+                    portfolio.append(
+                        dict(company=row["Company"],
+                             buy_date=buy_date,
+                             sell_date=sell_date,
+                             shares_bought=qty,
+                             buy_price=next_open)
+                    )
+
+        for pos in portfolio[:]:
+            if pos["sell_date"] is not None and curr_date == pos["sell_date"]:
+                px = df.loc[(df["Company"] == pos["company"]) &
+                            (df["Date"] == pos["sell_date"]), "Price"]
+                if px.empty:
+                    continue
+                px = px.iloc[0]
+                profit = (px - pos["buy_price"]) * pos["shares_bought"]
+                cash += pos["shares_bought"] * px
+                trades.append(profit > 0)
+                portfolio.remove(pos)
+
+        pv = 0
+        for pos in portfolio:
+            cur_px = df.loc[(df["Company"] == pos["company"]) &
+                            (df["Date"] == curr_date), "Price"]
+            if not cur_px.empty:
+                pv += pos["shares_bought"] * cur_px.iloc[0]
+        equity_curve.append(cash + pv)
+
+    total_contrib = INITIAL_INVEST + CONTRIB_AMOUNT * (len(date_index) // CONTRIB_FREQ)
+    final_val = equity_curve[-1]
+    roi = (final_val - total_contrib) / total_contrib * 100
+    win_rate = (sum(trades) / len(trades) * 100) if trades else 0
+
+    last_date = date_index[-1]
+    rows = []
+    for pos in portfolio:
+        last_px = df.loc[(df["Company"] == pos["company"]) &
+                         (df["Date"] == last_date), "Price"]
+        if last_px.empty:
+            continue
+        last_px = last_px.iloc[0]
+        pl_val = (last_px - pos["buy_price"]) * pos["shares_bought"]
+        pl_pct = (last_px - pos["buy_price"]) / pos["buy_price"] * 100
+        if pos["sell_date"] is not None:
+            days_remaining = (pos["sell_date"] - last_date).days
+        else:
+            days_held = (last_date - pos["buy_date"]).days
+            days_remaining = HOLD_DAYS - days_held
+        rows.append({
+            "Company": pos["company"],
+            "Shares": round(pos["shares_bought"], 2),
+            "Buy Date": pos["buy_date"].date(),
+            "Buy Price": round(pos["buy_price"], 2),
+            "Current Price": round(last_px, 2),
+            "P/L $": round(pl_val, 2),
+            "P/L %": round(pl_pct, 2),
+            "Days Remaining": days_remaining
+        })
+    open_df = pd.DataFrame(rows)
+
+    return (pd.Series(equity_curve, index=date_index),
+            round(final_val, 2), round(roi, 2), round(win_rate, 2), open_df)
+
+series_vals, final_val, roi, win_rate, open_df = run_backtest(df_sorted)
+
+# —— DASHBOARD ——
+st.title("\ud83d\udcc8 Project M – Trading Simulation")
+st.subheader(f"Today's Date: {date.today().isoformat()}")
+
+c1, c2, c3 = st.columns(3)
+c1.metric("Final Portfolio Value", f"${final_val:,.2f}")
+c2.metric("ROI", f"{roi:.2f}%")
+c3.metric("Win Rate", f"{win_rate:.2f}%")
+
+st.subheader("Portfolio Value Over Time")
+fig, ax = plt.subplots(figsize=(10, 4), facecolor="black")
+ax.set_facecolor("black")
+ax.plot(series_vals.index, series_vals.values, color="#00BFFF", linewidth=2)
+ax.set_xlabel("Date", color="white"); ax.set_ylabel("Total Portfolio Value ($)", color="white")
+ax.tick_params(colors="white"); ax.grid(alpha=0.3, color="gray")
+for spine in ax.spines.values(): spine.set_color("white")
+st.pyplot(fig, clear_figure=True)
+
+st.subheader("Open Positions")
+if open_df.empty:
+    st.info("No active trades.")
+else:
+    def colour(val):
+        if isinstance(val, (int, float)):
+            if val > 0: return "color:green;"
+            if val < 0: return "color:red;"
+        return ""
+    styled = (open_df.style
+              .applymap(colour, subset=["P/L $", "P/L %"])
+              .format(precision=2))
+    st.write(styled.to_html(index=False), unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- implement a Streamlit dashboard for trading simulation
- show today's date at the top of the dashboard

## Testing
- `python -m streamlit streamlit_dashboard.py` *(fails: Streamlit requires an interactive environment)*

------
https://chatgpt.com/codex/tasks/task_e_685c07adfb9c832bb30c4d2d46d72aa3