### PR TITLE
Plot % change for open positions

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -180,11 +180,12 @@ else:
             history = df_sorted[
                 (df_sorted["Company"] == row["Company"]) & (df_sorted["Date"] >= start)
             ]
-            ax2.plot(history["Date"], history["Price"], label=row["Company"])
+            pct_change = (history["Price"] - row["Buy Price"]) / row["Buy Price"] * 100
+            ax2.plot(history["Date"], pct_change, label=row["Company"])
 
         ax2.set_xlabel("Date", color="white")
-        ax2.set_ylabel("Price ($)", color="white")
-        ax2.tick_params(colors="white")
+        ax2.set_ylabel("Price Change (%)", color="white")
+        ax2.tick_params(colors="white", rotation=45)
         ax2.grid(alpha=0.3, color="gray")
         for spine in ax2.spines.values():
             spine.set_color("white")


### PR DESCRIPTION
## Summary
- chart open positions using percent change instead of price
- rotate x-axis labels so they don't overlap

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_685c1624d51c832b8efd51328838012a