### PR TITLE
Handle dataset gap in change metric

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -15,6 +15,9 @@ CONTRIB_AMOUNT = 3_000
 CONTRIB_FREQ = 22
 MANUAL_EXIT_DATE = pd.Timestamp("2024-06-27")
 HOLD_DAYS = 25
+# The dataset has a year long gap before 2025-06-20. Change metrics
+# should not cross this date when looking back in time.
+EARLIEST_CHANGE_DATE = pd.Timestamp("2025-06-20")
 
 # —— LOAD DATA ——
 @st.cache_data
@@ -181,8 +184,13 @@ timeframe_options = {"Weekly": 7, "Monthly": 30, "Yearly": 365}
 sel_col, metric_col = st.columns([1, 2])
 selected_tf = sel_col.selectbox("Change Period", list(timeframe_options.keys()))
 days = timeframe_options[selected_tf]
-idx = -days - 1 if len(series_vals) > days else 0
-start_val = series_vals.iloc[idx]
+candidate_idx = len(series_vals) - (days + 1) if len(series_vals) > days else 0
+try:
+    limit_idx = series_vals.index.get_loc(EARLIEST_CHANGE_DATE)
+except KeyError:
+    limit_idx = 0
+start_idx = max(candidate_idx, limit_idx)
+start_val = series_vals.iloc[start_idx]
 change = series_vals.iloc[-1] - start_val
 change_pct = (change / start_val * 100) if start_val != 0 else 0
 metric_col.metric(f"{selected_tf} Change", f"${change:,.2f}", f"{change_pct:.2f}%")


### PR DESCRIPTION
## Summary
- acknowledge data gap with `EARLIEST_CHANGE_DATE`
- prevent weekly/monthly/yearly change from crossing the gap

## Testing
- `python3 -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_685d65d5edbc832bbf2f360c515d36b7