### PR TITLE
Implement capital gains tax in trading simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ pip install -r requirements.txt
 streamlit run streamlit_app.py
 ```
 
-The app shows key statistics for the backtest, a portfolio value chart and a table of open positions.
+The app shows key statistics for the backtest, a portfolio value chart and a table of open positions.  All realised profits in the backtest are reduced by a 24% short‑term capital gains tax to provide a more realistic simulation.
 
 ## Deployment on Streamlit Community Cloud
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -15,6 +15,7 @@ CONTRIB_AMOUNT = 3_000
 CONTRIB_FREQ = 22
 MANUAL_EXIT_DATE = pd.Timestamp("2024-06-27")
 HOLD_DAYS = 25
+SHORT_TERM_TAX_RATE = 0.24  # 24% tax on short-term gains
 # The dataset has a year long gap before 2025-06-20. Change metrics
 # should not cross this date when looking back in time.
 EARLIEST_CHANGE_DATE = pd.Timestamp("2025-06-20")
@@ -55,6 +56,8 @@ def run_backtest(df):
                 px = px.iloc[0]
                 profit = (px - pos["buy_price"]) * pos["shares_bought"]
                 cash += pos["shares_bought"] * px
+                if profit > 0:
+                    cash -= profit * SHORT_TERM_TAX_RATE
                 trades.append(profit > 0)
                 trade_history.append(
                     dict(company=pos["company"],
@@ -102,6 +105,8 @@ def run_backtest(df):
                 px = px.iloc[0]
                 profit = (px - pos["buy_price"]) * pos["shares_bought"]
                 cash += pos["shares_bought"] * px
+                if profit > 0:
+                    cash -= profit * SHORT_TERM_TAX_RATE
                 trades.append(profit > 0)
                 trade_history.append(
                     dict(company=pos["company"],


### PR DESCRIPTION
## Summary
- apply a 24% short term gains tax when closing trades
- note the tax behavior in the README

## Testing
- `python -m py_compile streamlit_app.py`
- `python - <<'PY'
import streamlit_app as app
from pprint import pprint
series, final_val, roi, win_rate, open_df, trade_df = app.run_backtest(app.df_sorted)
print(final_val, roi, win_rate)
PY` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_68647df5ff00832bb4ce928e713b5897