### PR TITLE
Fix open positions display

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -141,6 +141,7 @@ def run_backtest(df):
             "Days Remaining": days_remaining
         })
     open_df = pd.DataFrame(rows)
+    open_df = open_df[open_df["Days Remaining"] >= 0].reset_index(drop=True)
 
     trades_df = pd.DataFrame(trade_history)
     return (


### PR DESCRIPTION
## Summary
- filter out negative `Days Remaining` in open positions list

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68669527f3e4832badc8b89c7168e87f