### PR TITLE
Align S&P500 backtest start date

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -188,6 +188,7 @@ def run_backtest(df):
 ) = run_backtest(df_sorted)
 
 sp_df = load_sp500(SP500_FILE)
+sp_df = sp_df[sp_df["Date"] >= date_index[0]]
 sp_series = simulate_sp500(sp_df)
 
 # —— DASHBOARD ——


### PR DESCRIPTION
## Summary
- filter S&P 500 dataset to start from the same date as the trading strategy

## Testing
- `python -m py_compile streamlit_app.py`
- *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6869c6e958dc832ba6e06789fec96aba