### PR TITLE
Add open position summary metrics

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -276,6 +276,14 @@ st.subheader("Open Positions")
 if open_df.empty:
     st.info("No active trades.")
 else:
+    # Calculate summary stats for open trades
+    total_trading = (open_df["Shares"] * open_df["Current Price"]).sum()
+    total_pl = open_df["P/L $"].sum()
+
+    mcol1, mcol2 = st.columns(2)
+    mcol1.metric("Capital in Active Trades", f"${total_trading:,.2f}")
+    mcol2.metric("Open Trade P/L", f"${total_pl:,.2f}")
+
     table_col, graph_col = st.columns(2)
 
     with table_col:


### PR DESCRIPTION
## Summary
- display extra metrics for open positions

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_687a5bdfb8e8832b922ca98be1a7e6d2